### PR TITLE
Corrigindo dependências.

### DIFF
--- a/documentos_br.gemspec
+++ b/documentos_br.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14.1"
-  spec.add_development_dependency "cpf_utils", "~> 1.2.1"
-  spec.add_development_dependency "cnpj_utils", "~> 1.0.1"
-  spec.add_development_dependency "titulo_eleitor_utils", "~> 1.0.0"
+  spec.add_dependency "cpf_utils", "~> 1.2.1"
+  spec.add_dependency "cnpj_utils", "~> 1.0.1"
+  spec.add_dependency "titulo_eleitor_utils", "~> 1.0.0"
 end


### PR DESCRIPTION
Como estava, era necessário adicionar todas as gems no Gemfile.

Com a mudança, o bundler deve baixar as dependências automaticamente.
